### PR TITLE
Use fixed minor version on L4T35

### DIFF
--- a/detector/docker.sh
+++ b/detector/docker.sh
@@ -41,17 +41,20 @@ then
     L4T_REVISION=$(echo $L4T_VERSION_STRING | cut -f 2 -d ',' | grep -Po '(?<=REVISION: )[^;]+')
     L4T_VERSION="$L4T_RELEASE.$L4T_REVISION"
     
-    if [ "$L4T_VERSION" == "32.6.1" ]; then # -------------------------------- This is jetson nano (python 3.9)
-        build_args+=" --build-arg BASE_IMAGE=zauberzeug/l4t-nn-inference-base:OCV4.6.0-L4T$L4T_VERSION-PY3.9"
-    elif [ "$L4T_RELEASE" == "35" ]; then # ------------------------------------------------------------------- This is jetson orin (python 3.8??)
+    if [ "$L4T_VERSION" == "32.6.1" ]; then
+        # do nothing
+        echo "Using exact L4T version 32.6.1"
+    if [ "$L4T_RELEASE" == "35" ]; then 
         # available versions of the dusty images: 32.7.1, 35.2.1, 35.3.1, 35.4.1
         # L4T R35.x containers can run on other versions of L4T R35.x (JetPack 5.1+)
         L4T_VERSION="35.4.1"
-        build_args+=" --build-arg BASE_IMAGE=dustynv/opencv:r$L4T_VERSION"
+        echo "Using L4T version 35.4.1 (dusty image for exact version $L4T_VERSION)"
     else
         echo "Unsupported L4T version: $L4T_VERSION"
         exit 1
     fi
+
+    build_args+=" --build-arg BASE_IMAGE=zauberzeug/l4t-nn-inference-base:OCV4.6.0-L4T$L4T_VERSION-PY3.9"
 
     image="zauberzeug/yolov5-detector:nlv$NODE_LIB_VERSION-$L4T_VERSION"
 else # ----------------------------------------------------------------------- This is cloud (linux) (python 3.10)


### PR DESCRIPTION
The latest version of the dustynv/opencv container uses L4T_VERSION="35.4.1".
However, as stated on its dockerhub page, any systems with L4T major version of 35 should support containers using any of its minor versions.
Therefore, we should always just use the latest one for that major version.


Sidenote: Apperently, this is not the case for earlier L4T versions like 32 