### PR TITLE
feature: trainer detecting

### DIFF
--- a/trainer/pred_det.py
+++ b/trainer/pred_det.py
@@ -182,7 +182,12 @@ def main(opt):
 
 
 if __name__ == "__main__":
-    torch.cuda.init()
+    try:
+        torch.cuda.init()
+    except RuntimeError as e:
+        print(e)
+        sys.exit(1)
+
     torch.cuda.empty_cache()
     opt = parse_opt()
     main(opt)


### PR DESCRIPTION
raise a restart error that triggers node restart if a cuda error occurs during detecting

- [x] check if the error messages are correct and can be read in the logs
- [x] check if such an error should be raised elsewhere