### PR TITLE
Update all nodes to nodelib 0.20.1 to fix orphaned training subprocess on abort

### DIFF
--- a/detector/pyproject.toml
+++ b/detector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolov5-detector"
-version = "1.0.4"
+version = "1.0.5"
 description = "YOLOv5 TensorRT detector node"
 authors = [{ name="Zauberzeug GmbH", email="info@zauberzeug.com" }]
 readme = "README.md"
@@ -20,7 +20,7 @@ dependencies = [
     "numpy",
     "pyyaml",
     "pycuda==2025.1.2",
-    "learning_loop_node==0.20.0",
+    "learning_loop_node==0.20.1",
     "typing_extensions",
 ]
 

--- a/detector/uv.lock
+++ b/detector/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "learning-loop-node"
-version = "0.20.0"
+version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -608,9 +608,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7b/152f37597c84c11d82608463a3b4cf77489338bde591048a8b58596c483d/learning_loop_node-0.20.0.tar.gz", hash = "sha256:65795c97728108ff5417f7cb24569b8a0d3ec95b32dc35de6d7fbd2101ac286b", size = 62661, upload-time = "2026-05-29T09:42:33.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/00/34e5870ce03c9096034c76eb9865d49b1c35694a8d6fd5bf1316bebadfc0/learning_loop_node-0.20.1.tar.gz", hash = "sha256:53d03ec6aa50330859186526acd0e2260f47806fafbb55f8135b75b4512e9dd2", size = 62716, upload-time = "2026-07-07T07:39:40.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/d9/7bb2b2d0530ff76596104da6dde76483b5a297f8934f0b50af41c8dc34ae/learning_loop_node-0.20.0-py3-none-any.whl", hash = "sha256:0f58f33be28b1c592c372824d0cdbbc687dc14351799190c54055052edbe78e3", size = 76940, upload-time = "2026-05-29T09:42:32.387Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/c64763fb3eefb9ba25fd4b2f50cf1264e63b62324e52e49c0105885afb79/learning_loop_node-0.20.1-py3-none-any.whl", hash = "sha256:b8c23e98cffbd4e1235179c835b6f27b4d486416714d91f46da2da05fa63035a", size = 76996, upload-time = "2026-07-07T07:39:39.074Z" },
 ]
 
 [[package]]
@@ -1888,7 +1888,7 @@ wheels = [
 
 [[package]]
 name = "yolov5-detector"
-version = "1.0.4"
+version = "1.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1927,7 +1927,7 @@ requires-dist = [
     { name = "async-timeout" },
     { name = "attrs" },
     { name = "idna-ssl" },
-    { name = "learning-loop-node", specifier = "==0.20.0" },
+    { name = "learning-loop-node", specifier = "==0.20.1" },
     { name = "multidict" },
     { name = "numpy" },
     { name = "pillow" },

--- a/detector_cpu/pyproject.toml
+++ b/detector_cpu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolov5-detector"
-version = "0.1.14"
+version = "0.1.15"
 description = "YOLOv5 TensorRT detector node"
 authors = [{ name="Zauberzeug GmbH", email="info@zauberzeug.com" }]
 readme = "README.md"
@@ -25,7 +25,7 @@ dependencies = [
     "idna_ssl",
     "aiosignal",
     "IPython",
-    "learning_loop_node==0.20.0",
+    "learning_loop_node==0.20.1",
 ]
 
 [dependency-groups]

--- a/detector_cpu/uv.lock
+++ b/detector_cpu/uv.lock
@@ -603,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "learning-loop-node"
-version = "0.20.0"
+version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -627,9 +627,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7b/152f37597c84c11d82608463a3b4cf77489338bde591048a8b58596c483d/learning_loop_node-0.20.0.tar.gz", hash = "sha256:65795c97728108ff5417f7cb24569b8a0d3ec95b32dc35de6d7fbd2101ac286b", size = 62661, upload-time = "2026-05-29T09:42:33.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/00/34e5870ce03c9096034c76eb9865d49b1c35694a8d6fd5bf1316bebadfc0/learning_loop_node-0.20.1.tar.gz", hash = "sha256:53d03ec6aa50330859186526acd0e2260f47806fafbb55f8135b75b4512e9dd2", size = 62716, upload-time = "2026-07-07T07:39:40.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/d9/7bb2b2d0530ff76596104da6dde76483b5a297f8934f0b50af41c8dc34ae/learning_loop_node-0.20.0-py3-none-any.whl", hash = "sha256:0f58f33be28b1c592c372824d0cdbbc687dc14351799190c54055052edbe78e3", size = 76940, upload-time = "2026-05-29T09:42:32.387Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/c64763fb3eefb9ba25fd4b2f50cf1264e63b62324e52e49c0105885afb79/learning_loop_node-0.20.1-py3-none-any.whl", hash = "sha256:b8c23e98cffbd4e1235179c835b6f27b4d486416714d91f46da2da05fa63035a", size = 76996, upload-time = "2026-07-07T07:39:39.074Z" },
 ]
 
 [[package]]
@@ -1777,7 +1777,7 @@ wheels = [
 
 [[package]]
 name = "yolov5-detector"
-version = "0.1.14"
+version = "0.1.15"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1821,7 +1821,7 @@ requires-dist = [
     { name = "attrs" },
     { name = "idna-ssl" },
     { name = "ipython" },
-    { name = "learning-loop-node", specifier = "==0.20.0" },
+    { name = "learning-loop-node", specifier = "==0.20.1" },
     { name = "multidict" },
     { name = "pillow" },
     { name = "psutil" },

--- a/trainer/pyproject.toml
+++ b/trainer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yolov5-trainer-node"
-version = "1.0.4"
+version = "1.0.5"
 description = "Yolov5 trainer node"
 authors = [{ name="Zauberzeug GmbH", email="info@zauberzeug.com" }]
 readme = "README.md"
@@ -8,7 +8,7 @@ requires-python = ">=3.12"
 
 dependencies = [
     "ruamel.yaml",
-    "learning_loop_node==0.20.0",
+    "learning_loop_node==0.20.1",
     "torchinfo>=1.8.0",
 ]
 

--- a/trainer/uv.lock
+++ b/trainer/uv.lock
@@ -972,7 +972,7 @@ wheels = [
 
 [[package]]
 name = "learning-loop-node"
-version = "0.20.0"
+version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -996,9 +996,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7b/152f37597c84c11d82608463a3b4cf77489338bde591048a8b58596c483d/learning_loop_node-0.20.0.tar.gz", hash = "sha256:65795c97728108ff5417f7cb24569b8a0d3ec95b32dc35de6d7fbd2101ac286b", size = 62661, upload-time = "2026-05-29T09:42:33.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/00/34e5870ce03c9096034c76eb9865d49b1c35694a8d6fd5bf1316bebadfc0/learning_loop_node-0.20.1.tar.gz", hash = "sha256:53d03ec6aa50330859186526acd0e2260f47806fafbb55f8135b75b4512e9dd2", size = 62716, upload-time = "2026-07-07T07:39:40.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/d9/7bb2b2d0530ff76596104da6dde76483b5a297f8934f0b50af41c8dc34ae/learning_loop_node-0.20.0-py3-none-any.whl", hash = "sha256:0f58f33be28b1c592c372824d0cdbbc687dc14351799190c54055052edbe78e3", size = 76940, upload-time = "2026-05-29T09:42:32.387Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/c64763fb3eefb9ba25fd4b2f50cf1264e63b62324e52e49c0105885afb79/learning_loop_node-0.20.1-py3-none-any.whl", hash = "sha256:b8c23e98cffbd4e1235179c835b6f27b4d486416714d91f46da2da05fa63035a", size = 76996, upload-time = "2026-07-07T07:39:39.074Z" },
 ]
 
 [[package]]
@@ -3044,7 +3044,7 @@ wheels = [
 
 [[package]]
 name = "yolov5-trainer-node"
-version = "1.0.4"
+version = "1.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "learning-loop-node" },
@@ -3087,7 +3087,7 @@ yolo = [
 
 [package.metadata]
 requires-dist = [
-    { name = "learning-loop-node", specifier = "==0.20.0" },
+    { name = "learning-loop-node", specifier = "==0.20.1" },
     { name = "ruamel-yaml" },
     { name = "torchinfo", specifier = ">=1.8.0" },
 ]


### PR DESCRIPTION
## Motivation

nodelib 0.20.1 fixes the abort flow introduced in 0.20.0: for executor-based trainers the training subprocess was left running (still holding the GPU) when a training was aborted. All nodes should pick up this fix.

## Implementation

- Update `learning_loop_node` pin from 0.20.0 to 0.20.1 in `detector`, `detector_cpu` and `trainer`
- Bump project versions: detector and trainer 1.0.4 → 1.0.5, detector_cpu 0.1.14 → 0.1.15
- Regenerate `uv.lock` in all three sub-projects

---
⬛ claude-fable-5