### PR TITLE
Sync CONTRIBUTING.md with data team style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,33 @@ ui.button('Speichern', on_click=self.save).props(
     'button-primary')
 ```
 
-## 4. Ordering: Important things first
+### 4. Comments
+
+We keep comments as few and as short as possible.
+A comment should only state what is needed to understand the code — not the motivation behind an implementation and not a restatement of what the code already says.
+If the code is clear on its own, it needs no comment.
+
+### 5. Error handling
+
+We do not use return values to signal success or failure.
+A function that returns `True`/`False` or `None` for this purpose forces every caller to remember the convention, and a forgotten check fails silently.
+Instead we raise exceptions — custom exception classes where appropriate — and handle them where the caller can react.
+
+```python
+# preferred
+def parse_config(path: Path) -> Config:
+    if not path.exists():
+        raise ConfigNotFoundError(path)
+    ...
+
+# avoid (None as failure signal)
+def parse_config(path: Path) -> Config | None:
+    if not path.exists():
+        return None
+    ...
+```
+
+## 6. Ordering: Important things first
 
 We want to have main classes and functions at the top of the file, while helper functions and classes should be placed below. This allows to quickly understand the main purpose of the file without having to scroll through a lot of code.
 
@@ -93,7 +119,7 @@ class ReportGenerator:
         ...
 ```
 
-## 5. Docstrings and type hints
+## 7. Docstrings and type hints
 
 We use the reStructuredText (reST) or Sphinx-style docstring format.
 We don't declare types in the docstring but use type hints.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,20 +16,84 @@ Then set it as the project interpreter in your IDE (e.g. Python: Select Interpre
 To publish a new release of the software (trainer and detectors), create a new release via github and use the [version number](https://semver.org/) as name and tag name with the pattern `v<MAJOR>.<MINOR>.<PATCH>`.
 This will automatically trigger a pipeline action that builds and publishes docker containers as defined in the [workflow file](.github/workflows/docker-deploy.yml).
 
+## Data Team Standards
+
+## Linting
+
+We use ruff and [pre-commit](https://github.com/pre-commit/pre-commit) to make sure the coding style is enforced.
+You first need to install pre-commit and the corresponding git commit hooks by running the following commands:
+
+```bash
+python3 -m pip install pre-commit
+pre-commit install
+```
+
+After that you can make sure your code satisfies the coding style by running the following command:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Style Guide
 
-### Single or double quotes
+### 1. Single or double quotes
 
 We use single quotes for strings in the code and double quotes for docstrings.
 Double quotes may also be used for strings if the string contains a single quote.
 
-### String formatting
+### 2. String formatting
 
 We use f-strings if possible (due to their readability).
 Logs shell use the lazy formatting provided by the logging (performance optimization).
 When diverging from above rules, please provide a short comment with `# NOTE: ...` to explaining the reason.
 
-## Docstrings and type hints
+### 3. Line continuation
+
+To break a long statement across multiple lines, we use a trailing backslash (`\`) to break between chained calls, rather than breaking inside a call's parentheses. This reads better for
+fluent/builder chains such as NiceGUI element construction, where the leading `.` on each line clearly marks the continuation and each call keeps its arguments together.
+
+```python
+# preferred
+ui.button('Speichern', on_click=self.save)\
+    .props('no-caps')\
+    .classes('button-primary')
+
+# avoid (using the open parenthesis of a call to wrap)
+ui.button('Speichern', on_click=self.save).props(
+    'no-caps').classes(
+    'button-primary')
+```
+
+## 4. Ordering: Important things first
+
+We want to have main classes and functions at the top of the file, while helper functions and classes should be placed below. This allows to quickly understand the main purpose of the file without having to scroll through a lot of code.
+
+The same rule applies within a class:
+
+- The public interface comes first: the constructor, then the public methods and properties.
+- Every private helper is placed below the methods that call it, so a reader always meets the caller before the callee.
+- If a helper is called by several methods, it is placed below all of them.
+
+```python
+class ReportGenerator:
+
+    def __init__(self, source: Path) -> None:
+        self.source = source
+
+    def generate_summary(self) -> str:
+        rows = self._load_rows()
+        ...
+
+    def generate_details(self) -> str:
+        rows = self._load_rows()
+        ...
+
+    def _load_rows(self) -> list[Row]:
+        """Called by generate_summary and generate_details, so it comes after both."""
+        ...
+```
+
+## 5. Docstrings and type hints
 
 We use the reStructuredText (reST) or Sphinx-style docstring format.
 We don't declare types in the docstring but use type hints.


### PR DESCRIPTION
Syncs CONTRIBUTING.md with the data team standard (`templates/CONTRIBUTING.md` in the [data_team repo](https://github.com/zauberzeug/data_team)).

Changes:

- Added the `## Data Team Standards` marker heading above the Style Guide. Content below it is kept in sync with the template; the repo-specific sections (setup, publishing releases) stay above it, unchanged.
- Added the missing Linting section, rule 3 (Line continuation) and rule 4 (Ordering: important things first, file level and within a class).
- Numbered the style rules (1–5) for easier referencing.

Unchanged: rules 1–2 (quotes, string formatting) and rule 5 (docstrings and type hints) — they already matched the template.